### PR TITLE
Add CasTex to Texturing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ If you consider our paper or list useful, please cite our paper:
 - [StableMaterials: Enhancing Diversity in Material Generation via Semi-Supervised Learning](https://arxiv.org/abs/2406.09293) Vecchio et al., Arxiv 2024
 - [TexGen: Text-Guided 3D Texture Generation with Multi-view Sampling and Resampling](https://arxiv.org/abs/2408.01291), Huo et al., Arxiv 2024
 - [ControlMat: A Controlled Generative Approach to Material Capture](https://arxiv.org/abs/2309.01700) Vecchio et al., ACM ToG 2024
+- [CasTex: Cascaded Text-to-Texture Synthesis via Explicit Texture Maps and Physically-Based Shading](https://arxiv.org/abs/2504.06856), Aliev et al., WACV 2026
 
 ### Multi-view Diffusion
 - [MVDiffusion: Enabling Holistic Multi-view Image Generation with Correspondence-Aware Diffusion](https://arxiv.org/abs/2307.01097), Tang et al., Arxiv 2023


### PR DESCRIPTION
Hello! I would like to add our accepted paper **CasTex** to 
**Paper:** CasTex: Cascaded Text-to-Texture Synthesis via Explicit Texture Maps and Physically-Based Shading
**Authors:** Mishan Aliev, Dmitry Baranchuk, Kirill Struminsky
**Arxiv:** https://arxiv.org/abs/2504.06856 (Accepted WACV'2026)
**Project Page:** https://thecrazymage.github.io/CasTex/
**Code:** https://github.com/thecrazymage/CasTex/
**BibTeX:**
```
@article{aliev2025castex,
  title={CasTex: Cascaded Text-to-Texture Synthesis via Explicit Texture Maps and Physically-Based Shading},
  author={Aliev, Mishan and Baranchuk, Dmitry and Struminsky, Kirill},
  journal={arXiv preprint arXiv:2504.06856},
  year={2025}
}
```

**Why it fits:**
This work introduces a text-to-texture synthesis method that generates high-quality **PBR materials** (Albedo, Roughness, Metallic, Normal). Unlike previous optimization-based methods (like Paint-it or Fantasia3D) that rely on Latent Diffusion Models and suffer from oversaturation artifacts, CasTex employs **Score Distillation Sampling (SDS) in pixel space** using Cascaded Diffusion Models (DeepFloyd-IF). This approach eliminates the need for implicit regularization (DIP) and achieves state-of-the-art results on Objaverse benchmarks.


Thanks in advance for your help!